### PR TITLE
Soarais 2123 support xsi namespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 
 	<build>
     	
-		<finalName>cerner-codevalidator-${version}</finalName>
+		<finalName>cerner-codevalidator-api-${version}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/sitenv/vocabularies/validation/pool/AutoPilotWrapper.java
+++ b/src/main/java/org/sitenv/vocabularies/validation/pool/AutoPilotWrapper.java
@@ -36,6 +36,7 @@ public class AutoPilotWrapper {
 			this.autopilot.declareXPathNameSpace("v3", "urn:hl7-org:v3");
 			this.autopilot.declareXPathNameSpace("voc", "urn:hl7-org:v3/voc");
 			this.autopilot.declareXPathNameSpace("", "urn:hl7-org:v3");
+			this.autopilot.declareXPathNameSpace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
 			this.autopilot.selectXPath(this.xpath);
 			ok = true;
 		} catch (Exception e) {

--- a/src/main/java/org/sitenv/vocabularies/validation/services/VocabularyValidationService.java
+++ b/src/main/java/org/sitenv/vocabularies/validation/services/VocabularyValidationService.java
@@ -123,7 +123,7 @@ public class VocabularyValidationService {
 		if (doc != null) {
 			String configuredXpathExpression = "";
 			try {
-				XPath xpath = getNewXpath(doc);
+				XPath xpath = getNewXpath(doc, xPathFactory);
 
 				/*
 				 * Updated for loop to call getVocabValidationConfigurations
@@ -194,7 +194,7 @@ public class VocabularyValidationService {
 		return resultMap;
 	}
 
-	private XPath getNewXpath(final Document doc) {
+	public static XPath getNewXpath(final Document doc, XPathFactory xPathFactory) {
 		XPath xpath = xPathFactory.newXPath();
 		xpath.setNamespaceContext(new NamespaceContext() {
             @Override

--- a/src/main/java/org/sitenv/vocabularies/validation/services/VocabularyValidationService.java
+++ b/src/main/java/org/sitenv/vocabularies/validation/services/VocabularyValidationService.java
@@ -197,16 +197,18 @@ public class VocabularyValidationService {
 	private XPath getNewXpath(final Document doc) {
 		XPath xpath = xPathFactory.newXPath();
 		xpath.setNamespaceContext(new NamespaceContext() {
-			@Override
-			public String getNamespaceURI(String prefix) {
-				String nameSpace;
-				if (CCDADocumentNamespaces.sdtc.name().equals(prefix)) {
-					nameSpace = CCDADocumentNamespaces.sdtc.getNamespace();
-				} else {
-					nameSpace = CCDADocumentNamespaces.defaultNameSpaceForCcda.getNamespace();
-				}
-				return nameSpace;
-			}
+            @Override
+            public String getNamespaceURI(String prefix) {
+                String nameSpace;
+                if(CCDADocumentNamespaces.sdtc.name().equals(prefix)) {
+                    nameSpace = CCDADocumentNamespaces.sdtc.getNamespace();
+                } else if(CCDADocumentNamespaces.xsi.name().equals(prefix)) {
+                	nameSpace = CCDADocumentNamespaces.xsi.getNamespace();
+                } else {
+                    nameSpace = CCDADocumentNamespaces.defaultNameSpaceForCcda.getNamespace();
+                }
+                return nameSpace;
+            }
 
 			@Override
 			public String getPrefix(String namespaceURI) {

--- a/src/main/java/org/sitenv/vocabularies/validation/utils/CCDADocumentNamespaces.java
+++ b/src/main/java/org/sitenv/vocabularies/validation/utils/CCDADocumentNamespaces.java
@@ -4,7 +4,8 @@ public enum CCDADocumentNamespaces {
     sdtc ("urn:hl7-org:sdtc"),
     v3 ("urn:hl7-org:v3"),
     defaultNameSpaceForCcda ("urn:hl7-org:v3"),
-    voc ("urn:hl7-org:v3/voc");
+    voc ("urn:hl7-org:v3/voc"),
+    xsi ("http://www.w3.org/2001/XMLSchema-instance");
 
     private final String namespace;
 


### PR DESCRIPTION
SOARAIS-2123 - Update OSS codeValidator to support new xsi namespace.

- Added new xsi namespace support.
- Exposed getNewXpath method from codeValidator's VocabularyValidationService Java class as a public static method so the referenceccdavalidator can use it as well.